### PR TITLE
Add delivery descriptions, price list, and blackjack game

### DIFF
--- a/bot/database/methods/create.py
+++ b/bot/database/methods/create.py
@@ -22,10 +22,12 @@ def create_user(telegram_id: int, registration_date, referral_id, role: int = 1,
             session.commit()
 
 
-def create_item(item_name: str, item_description: str, item_price: int, category_name: str) -> None:
+def create_item(item_name: str, item_description: str, item_price: int, category_name: str,
+                delivery_description: str | None = None) -> None:
     session = Database().session
     session.add(
-        Goods(name=item_name, description=item_description, price=item_price, category_name=category_name))
+        Goods(name=item_name, description=item_description, price=item_price,
+              category_name=category_name, delivery_description=delivery_description))
     session.commit()
 
 

--- a/bot/database/methods/update.py
+++ b/bot/database/methods/update.py
@@ -31,7 +31,8 @@ def buy_item_for_balance(telegram_id: str, summ: int) -> int:
     return Database().session.query(User.balance).filter(User.telegram_id == telegram_id).one()[0]
 
 
-def update_item(item_name: str, new_name: str, new_description: str, new_price: int, new_category_name: str) -> None:
+def update_item(item_name: str, new_name: str, new_description: str, new_price: int,
+                new_category_name: str, new_delivery_description: str | None) -> None:
     Database().session.query(ItemValues).filter(ItemValues.item_name == item_name).update(
         values={ItemValues.item_name: new_name}
     )
@@ -39,7 +40,8 @@ def update_item(item_name: str, new_name: str, new_description: str, new_price: 
         values={Goods.name: new_name,
                 Goods.description: new_description,
                 Goods.price: new_price,
-                Goods.category_name: new_category_name}
+                Goods.category_name: new_category_name,
+                Goods.delivery_description: new_delivery_description}
     )
     Database().session.commit()
 

--- a/bot/database/models/main.py
+++ b/bot/database/models/main.py
@@ -108,14 +108,17 @@ class Goods(Database.BASE):
     name = Column(String(100), nullable=False, unique=True, primary_key=True)
     price = Column(BigInteger, nullable=False)
     description = Column(Text, nullable=False)
+    delivery_description = Column(Text, nullable=True)
     category_name = Column(String(100), ForeignKey('categories.name'), nullable=False)
     category = relationship("Categories", back_populates="item")
     values = relationship("ItemValues", back_populates="item")
 
-    def __init__(self, name: str, price: int, description: str, category_name: str):
+    def __init__(self, name: str, price: int, description: str, category_name: str,
+                 delivery_description: str | None = None):
         self.name = name
         self.price = price
         self.description = description
+        self.delivery_description = delivery_description
         self.category_name = category_name
 
 

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import os
+import random
 from io import BytesIO
 from urllib.parse import urlparse
 import html
@@ -15,7 +16,7 @@ from bot.database.methods import (
     select_max_role_id, create_user, check_role, check_user,
     get_all_categories, get_all_items, select_bought_items, get_bought_item_info, get_item_info,
     select_item_values_amount, get_user_balance, get_item_value, buy_item, add_bought_item, buy_item_for_balance,
-    select_user_operations, select_user_items, check_user_referrals, start_operation,
+    select_user_operations, select_user_items, start_operation,
     select_unfinished_operations, get_user_referral, finish_operation, update_balance, create_operation,
     bought_items_list, check_value, get_subcategories, get_category_parent, get_user_language, update_user_language,
     get_unfinished_operation
@@ -23,7 +24,7 @@ from bot.database.methods import (
 from bot.utils.files import cleanup_item_file
 from bot.handlers.other import get_bot_user_ids, get_bot_info
 from bot.keyboards import main_menu, categories_list, goods_list, subcategories_list, user_items_list, back, item_info, \
-    profile, rules, payment_menu, close, crypto_choice, crypto_invoice_menu
+    profile, rules, payment_menu, close, crypto_choice, crypto_invoice_menu, blackjack_controls
 from bot.localization import t
 from bot.logger_mesh import logger
 from bot.misc import TgConfig, EnvKeys
@@ -57,6 +58,24 @@ def build_subcategory_description(parent: str, lang: str) -> str:
         lines.append("")
     lines.append(t(lang, 'choose_subcategory'))
     return "\n".join(lines)
+
+
+def blackjack_hand_value(cards: list[int]) -> int:
+    total = sum(cards)
+    aces = cards.count(11)
+    while total > 21 and aces:
+        total -= 10
+        aces -= 1
+    return total
+
+
+def format_blackjack_state(player: list[int], dealer: list[int], hide_dealer: bool = True) -> str:
+    player_text = ", ".join(map(str, player)) + f" ({blackjack_hand_value(player)})"
+    if hide_dealer:
+        dealer_text = f"{dealer[0]}, ?"
+    else:
+        dealer_text = ", ".join(map(str, dealer)) + f" ({blackjack_hand_value(dealer)})"
+    return f"🃏 Blackjack\nYour hand: {player_text}\nDealer: {dealer_text}"
 
 
 
@@ -118,6 +137,125 @@ async def close_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     await bot.delete_message(chat_id=call.message.chat.id,
                              message_id=call.message.message_id)
+
+
+async def price_list_callback_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    TgConfig.STATE[user_id] = None
+    lines = ['📋 Price list']
+    for category in get_all_categories():
+        lines.append(f"\n<b>{category}</b>")
+        for sub in get_subcategories(category):
+            lines.append(f"  {sub}")
+            for item in get_all_items(sub):
+                info = get_item_info(item)
+                lines.append(f"    • {item} ({info['price']:.2f}€)")
+        for item in get_all_items(category):
+            info = get_item_info(item)
+            lines.append(f"  • {item} ({info['price']:.2f}€)")
+    text = '\n'.join(lines)
+    await call.answer()
+    await bot.send_message(call.message.chat.id, text,
+                           parse_mode='HTML', reply_markup=back('back_to_menu'))
+
+
+async def blackjack_callback_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    TgConfig.STATE[user_id] = 'blackjack_bet'
+    TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
+    await bot.edit_message_text('Enter bet (max 2€):',
+                               chat_id=call.message.chat.id,
+                               message_id=call.message.message_id,
+                               reply_markup=back('profile'))
+
+
+async def process_blackjack_bet(message: Message):
+    bot, user_id = await get_bot_user_ids(message)
+    message_id = TgConfig.STATE.get(f'{user_id}_message_id')
+    await bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
+    try:
+        bet = int(message.text)
+    except ValueError:
+        await bot.edit_message_text('Invalid bet amount.',
+                                   chat_id=message.chat.id,
+                                   message_id=message_id,
+                                   reply_markup=back('profile'))
+        TgConfig.STATE[user_id] = None
+        return
+    balance = get_user_balance(user_id)
+    if bet <= 0 or bet > 2 or bet > balance:
+        await bot.edit_message_text('Invalid bet amount.',
+                                   chat_id=message.chat.id,
+                                   message_id=message_id,
+                                   reply_markup=back('profile'))
+        TgConfig.STATE[user_id] = None
+        return
+
+    buy_item_for_balance(user_id, bet)
+    deck = [2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11] * 4
+    random.shuffle(deck)
+    player = [deck.pop(), deck.pop()]
+    dealer = [deck.pop(), deck.pop()]
+    TgConfig.STATE[f'{user_id}_blackjack'] = {
+        'deck': deck,
+        'player': player,
+        'dealer': dealer,
+        'bet': bet
+    }
+    TgConfig.STATE[user_id] = 'blackjack_game'
+    text = format_blackjack_state(player, dealer, hide_dealer=True)
+    await bot.edit_message_text(text,
+                               chat_id=message.chat.id,
+                               message_id=message_id,
+                               reply_markup=blackjack_controls())
+
+
+async def blackjack_move_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    game = TgConfig.STATE.get(f'{user_id}_blackjack')
+    if not game:
+        await call.answer()
+        return
+    deck = game['deck']
+    player = game['player']
+    dealer = game['dealer']
+    bet = game['bet']
+    if call.data == 'blackjack_hit':
+        player.append(deck.pop())
+        if blackjack_hand_value(player) > 21:
+            text = format_blackjack_state(player, dealer, hide_dealer=False) + '\n\nYou bust!'
+            await bot.edit_message_text(text,
+                                       chat_id=call.message.chat.id,
+                                       message_id=call.message.message_id,
+                                       reply_markup=back('back_to_menu'))
+            TgConfig.STATE.pop(f'{user_id}_blackjack', None)
+            TgConfig.STATE[user_id] = None
+        else:
+            text = format_blackjack_state(player, dealer, hide_dealer=True)
+            await bot.edit_message_text(text,
+                                       chat_id=call.message.chat.id,
+                                       message_id=call.message.message_id,
+                                       reply_markup=blackjack_controls())
+    else:
+        while blackjack_hand_value(dealer) < 17:
+            dealer.append(deck.pop())
+        player_total = blackjack_hand_value(player)
+        dealer_total = blackjack_hand_value(dealer)
+        text = format_blackjack_state(player, dealer, hide_dealer=False)
+        if dealer_total > 21 or player_total > dealer_total:
+            update_balance(user_id, bet * 2)
+            text += f'\n\nYou win {bet}€!'
+        elif player_total == dealer_total:
+            update_balance(user_id, bet)
+            text += '\n\nPush.'
+        else:
+            text += '\n\nDealer wins.'
+        await bot.edit_message_text(text,
+                                   chat_id=call.message.chat.id,
+                                   message_id=call.message.message_id,
+                                   reply_markup=back('back_to_menu'))
+        TgConfig.STATE.pop(f'{user_id}_blackjack', None)
+        TgConfig.STATE[user_id] = None
 
 
 async def shop_callback_handler(call: CallbackQuery):
@@ -268,6 +406,7 @@ async def buy_item_callback_handler(call: CallbackQuery):
     msg = call.message.message_id
     item_info_list = get_item_info(item_name)
     item_price = item_info_list["price"]
+    delivery_desc = item_info_list.get("delivery_description")
     user_balance = get_user_balance(user_id)
 
     if user_balance >= item_price:
@@ -279,12 +418,14 @@ async def buy_item_callback_handler(call: CallbackQuery):
             new_balance = buy_item_for_balance(user_id, item_price)
             if os.path.isfile(value_data['value']):
                 with open(value_data['value'], 'rb') as photo:
+                    caption = f'✅ Item purchased. <b>Balance</b>: <i>{new_balance}</i>€'
+                    if delivery_desc:
+                        caption += f'\n\n{delivery_desc}'
                     await bot.send_photo(
                         chat_id=call.message.chat.id,
                         photo=photo,
-                        caption=f'✅ Item purchased. <b>Balance</b>: <i>{new_balance}</i>€',
-                        parse_mode='HTML',
-                        reply_markup=home_markup(get_user_language(user_id) or 'en')
+                        caption=caption,
+                        parse_mode='HTML'
                     )
                 os.remove(value_data['value'])
                 await bot.edit_message_text(chat_id=call.message.chat.id,
@@ -295,9 +436,12 @@ async def buy_item_callback_handler(call: CallbackQuery):
                 cleanup_item_file(value_data['value'])
 
             else:
+                text = f'✅ Item purchased. <b>Balance</b>: <i>{new_balance}</i>€\n\n{value_data["value"]}'
+                if delivery_desc:
+                    text += f'\n\n{delivery_desc}'
                 await bot.edit_message_text(chat_id=call.message.chat.id,
                                            message_id=msg,
-                                           text=f'✅ Item purchased. <b>Balance</b>: <i>{new_balance}</i>€\n\n{value_data["value"]}',
+                                           text=text,
                                            parse_mode='HTML',
                                            reply_markup=home_markup(get_user_language(user_id) or 'en')
                 )
@@ -415,8 +559,7 @@ async def profile_callback_handler(call: CallbackQuery):
             overall_balance += i
 
     items = select_user_items(user_id)
-    referral = TgConfig.REFERRAL_PERCENT
-    markup = profile(referral, items)
+    markup = profile(items)
     await bot.edit_message_text(text=f"👤 <b>Profile</b> — {user.first_name}\n🆔"
                                      f" <b>ID</b> — <code>{user_id}</code>\n"
                                      f"💳 <b>Balance</b> — <code>{balance}</code> €\n"
@@ -425,22 +568,6 @@ async def profile_callback_handler(call: CallbackQuery):
                                 chat_id=call.message.chat.id,
                                 message_id=call.message.message_id, reply_markup=markup,
                                 parse_mode='HTML')
-
-
-async def referral_callback_handler(call: CallbackQuery):
-    bot, user_id = await get_bot_user_ids(call)
-    TgConfig.STATE[user_id] = None
-    referrals = check_user_referrals(user_id)
-    referral_percent = TgConfig.REFERRAL_PERCENT
-    await bot.edit_message_text(f'💚 Referral system\n'
-                                f'🔗 Link: https://t.me/{await get_bot_info(call)}?start={user_id}\n'
-                                f'Number of referrals: {referrals}\n'
-                                f'📔 The referral system allows you to earn money without investment. '
-                                f'Just share your referral link and you will receive'
-                                f' {referral_percent}% of your referrals top-ups to your bot balance.',
-                                chat_id=call.message.chat.id,
-                                message_id=call.message.message_id,
-                                reply_markup=back('profile'))
 
 
 async def replenish_balance_callback_handler(call: CallbackQuery):
@@ -696,8 +823,12 @@ def register_user_handlers(dp: Dispatcher):
                                        lambda c: c.data == 'rules')
     dp.register_callback_query_handler(replenish_balance_callback_handler,
                                        lambda c: c.data == 'replenish_balance')
-    dp.register_callback_query_handler(referral_callback_handler,
-                                       lambda c: c.data == 'referral_system')
+    dp.register_callback_query_handler(price_list_callback_handler,
+                                       lambda c: c.data == 'price_list')
+    dp.register_callback_query_handler(blackjack_callback_handler,
+                                       lambda c: c.data == 'blackjack')
+    dp.register_callback_query_handler(blackjack_move_handler,
+                                       lambda c: c.data in ('blackjack_hit', 'blackjack_stand'))
     dp.register_callback_query_handler(bought_items_callback_handler,
                                        lambda c: c.data == 'bought_items')
     dp.register_callback_query_handler(back_to_menu_callback_handler,
@@ -740,3 +871,5 @@ def register_user_handlers(dp: Dispatcher):
 
     dp.register_message_handler(process_replenish_balance,
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'process_replenish_balance')
+    dp.register_message_handler(process_blackjack_bet,
+                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'blackjack_bet')

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -33,7 +33,7 @@ def main_menu(role: int, reviews: str = None, price: str = None, lang: str = 'en
     if reviews:
         row3.append(InlineKeyboardButton(t(lang, 'reviews'), url=reviews))
     if price:
-        row3.append(InlineKeyboardButton(t(lang, 'price_list'), url=price))
+        row3.append(InlineKeyboardButton(t(lang, 'price_list'), callback_data='price_list'))
     if row3:
         inline_keyboard.append(row3)
 
@@ -128,13 +128,11 @@ def item_info(item_name: str, category_name: str, lang: str) -> InlineKeyboardMa
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
 
-def profile(referral_percent: int, user_items: int = 0) -> InlineKeyboardMarkup:
+def profile(user_items: int = 0) -> InlineKeyboardMarkup:
     inline_keyboard = [
-        [InlineKeyboardButton('💸 Top up balance', callback_data='replenish_balance')
-         ]
+        [InlineKeyboardButton('💸 Top up balance', callback_data='replenish_balance')]
     ]
-    if referral_percent != 0:
-        inline_keyboard.append([InlineKeyboardButton('🎲 Referral system', callback_data='referral_system')])
+    inline_keyboard.append([InlineKeyboardButton('🃏 Blackjack', callback_data='blackjack')])
     if user_items != 0:
         inline_keyboard.append([InlineKeyboardButton('🎁 Purchased items', callback_data='bought_items')])
     inline_keyboard.append([InlineKeyboardButton('🔙 Back to menu', callback_data='back_to_menu')])
@@ -316,5 +314,13 @@ def question_buttons(question: str, back_data: str) -> InlineKeyboardMarkup:
          ],
         [InlineKeyboardButton('🔙 Go back', callback_data=back_data)
          ]
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
+def blackjack_controls() -> InlineKeyboardMarkup:
+    inline_keyboard = [
+        [InlineKeyboardButton('🃏 Hit', callback_data='blackjack_hit'),
+         InlineKeyboardButton('🛑 Stand', callback_data='blackjack_stand')]
     ]
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)

--- a/bot/misc/config.py
+++ b/bot/misc/config.py
@@ -7,7 +7,7 @@ class TgConfig(ABC):
     BASKETS: Final = {}
     CHANNEL_URL: Final = 'https://t.me/NBAXSHOP'
     HELPER_URL: Final = '@SugarFromShef'
-    REVIEWS_URL: Final = 'https://t.me/NBAXSHOP_reviews'
+    REVIEWS_URL: Final = 'https://t.me/+-yPLEiJwp-IxYzlk'
     PRICE_LIST_URL: Final = 'https://t.me/NBAXSHOP_price'
     GROUP_ID: Final = -988765433
     REFERRAL_PERCENT = 5

--- a/migrations/versions/82f4e758ad31_initial_migration.py
+++ b/migrations/versions/82f4e758ad31_initial_migration.py
@@ -42,6 +42,7 @@ def upgrade() -> None:
                     sa.Column('name', sa.String(length=100), nullable=False),
                     sa.Column('price', sa.BigInteger(), nullable=False),
                     sa.Column('description', sa.Text(), nullable=False),
+                    sa.Column('delivery_description', sa.Text(), nullable=True),
                     sa.Column('category_name', sa.String(length=100), nullable=False),
                     sa.ForeignKeyConstraint(['category_name'], ['categories.name'], ),
                     sa.PrimaryKeyConstraint('name'),


### PR DESCRIPTION
## Summary
- Allow admins to attach optional delivery descriptions to goods and send them to buyers.
- Show an in-bot price list of available categories and items.
- Replace referral system with a blackjack game tied to user balance.

## Testing
- `python -m py_compile bot/database/methods/create.py bot/database/methods/update.py bot/database/models/main.py bot/handlers/admin/shop_management_states.py bot/handlers/user/main.py bot/keyboards/inline.py bot/misc/config.py migrations/versions/82f4e758ad31_initial_migration.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a21e91980083329384e5c36e6276bd